### PR TITLE
ci: what the counter weighs, and a check that says so

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,3 +11,7 @@ crates/frus-demo/assets/licenses.txt -text
 *.ttf binary
 *.otf binary
 *.dex binary
+
+# Shell scripts run under bash — in CI, and in WSL straight from a Windows checkout — and
+# bash reads a carriage return as part of the command. Always LF (milestone 508).
+*.sh text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,45 @@ jobs:
           cargo apk build -p frus-hello --lib
 
   # ---------------------------------------------------------------------------
+  # The size of the smallest application (milestone 508, #9): `frus-hello` built
+  # in release for aarch64 Android, its stripped `.so` measured against the budget
+  # in ci/size-budget.toml. Nothing else in CI would notice if it doubled.
+  #
+  # The library is built with the NDK's linker directly rather than through
+  # cargo-apk: the `.so` is what is measured, and a release APK would need a
+  # signing key. API 24 is frus-hello's `min_sdk_version`.
+  #
+  # Blocking, unlike the build above: it catches a jump, not drift (the budget
+  # file argues the headroom), so a red run is a change to look at.
+  # ---------------------------------------------------------------------------
+  size:
+    name: Size budget (Android)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-linux-android
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: nttld/setup-ndk@v1
+        id: ndk
+        with:
+          ndk-version: r26d
+
+      - name: Build frus-hello (release, aarch64 Android)
+        env:
+          NDK_BIN: ${{ steps.ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin
+        run: |
+          export CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER="$NDK_BIN/aarch64-linux-android24-clang"
+          export CC_aarch64_linux_android="$NDK_BIN/aarch64-linux-android24-clang"
+          export AR_aarch64_linux_android="$NDK_BIN/llvm-ar"
+          cargo build --release -p frus-hello --lib --target aarch64-linux-android
+
+      - name: Compare with the budget
+        run: bash scripts/check-size.sh target/aarch64-linux-android/release/libfrus_hello.so
+
+  # ---------------------------------------------------------------------------
   # iOS target. `frus-shell` has explicit platform cfg aliases (`desktop` /
   # `android` / `ios` / `web`, see its build.rs) so that iOS does not fall into the
   # desktop branch and inherit arboard, env_logger and AccessKit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ any release may break.
 > frus is **pre-alpha** and **not on crates.io**. Releases are tagged source releases:
 > depend on them by `path` or by git revision. For the reasoning behind any individual
 > decision, the milestone notes in [`docs/milestone-*.md`](docs/) remain the authoritative
-> record — one per step, 507 so far, each documenting the objective, the alternatives
+> record — one per step, 508 so far, each documenting the objective, the alternatives
 > weighed, and the decision.
 
 ## [Unreleased]
@@ -119,6 +119,12 @@ any release may break.
 
 ### Added
 
+- **A size budget for the smallest application** (J508, answers #9). Nothing in CI would
+  notice if the counter doubled. A `size` job builds `frus-hello` for aarch64 Android in
+  release and `scripts/check-size.sh` compares the stripped `.so` with
+  `ci/size-budget.toml`, printing the size and the budget on every run. Today: 10,427,568
+  bytes, 4% over milestone 292's; the budget is 13,000,000, headroom for drift and not for
+  a jump. Blocking.
 - **Two different children, both on the screen for a moment** (J502, part of #30):
   `AnimatedSwitcher`. The old child leaves as the new one arrives — a fade by default, any
   explicit transition through `.transition`, placed by `.layout`, on separate in and out

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -150,7 +150,7 @@ The web target renders and animates but is missing its platform integrations. Ea
 Milestone 292 took a release APK from 286 MB to 4.9 MB by building `--release` at all. What is left is real work, not settings.
 
 - 🟡 **Subset the bundled faces at build time.** DejaVu covers far more of Unicode than any one application draws, and the four `bundled-*` features are a coarse instrument next to a `pyftsubset` step over the glyphs a build actually references. This is where the next megabyte is, and it needs a tool in the build.
-- 🟢 **A size regression check in CI.** Nothing notices today if the floor doubles. Build `frus-hello` for `aarch64-linux-android` in release, compare the stripped `.so` against a committed budget, fail on a jump.
+- 🟢 **A size regression check in CI — done, milestone 508 (#9).** A `size` job builds `frus-hello` for `aarch64-linux-android` in release — the NDK's linker directly, since a release APK would need a signing key and the `.so` is what is measured — and `scripts/check-size.sh` compares the stripped library with `ci/size-budget.toml`, printing the size, the compressed size and the budget on every run, a passing one included. Today's counter is **10,427,568 bytes**, 4% more than milestone 292's first measurement; the budget is 13,000,000, about 25% over — there to catch a jump (the release profile gone, LTO or stripping off, a dependency that brings an ecosystem, a font bundled by default), not the 4% two hundred milestones of drift came to. Blocking, and raised deliberately, in the change that needs it.
 - 🟢 **Document `--split-per-abi`-style packaging.** The examples build `aarch64` only; an application targeting more than one ABI wants a split rather than a fat APK, and nothing says so.
 
 ### Quality

--- a/ci/size-budget.toml
+++ b/ci/size-budget.toml
@@ -1,0 +1,23 @@
+# The size budget for the smallest frus application (milestone 508, #9).
+#
+# What is measured: `frus-hello`, the counter, built for aarch64-linux-android with the
+# workspace's release profile -- the stripped `libfrus_hello.so` an APK ships. Checked by
+# the `size` job in .github/workflows/ci.yml through scripts/check-size.sh, which prints
+# the size and this budget on every run.
+#
+# Where the number comes from:
+#
+#   milestone 292 (the first measurement)   10,012,520 bytes
+#   milestone 508 (this budget set)         10,427,568 bytes   -- +4% in 216 milestones
+#
+# The budget is about 25% over the measurement. It is there to catch a jump, not drift:
+# the release profile going missing (the debug library was 300 MB), LTO or stripping
+# turned off, a dependency that brings half an ecosystem with it, a font bundled by
+# default. Ordinary growth has been 4% in two hundred milestones, so this leaves years
+# of it -- and a single change that adds 2.5 MB to a counter is a change worth stopping
+# to look at.
+#
+# Raising it is allowed, and meant to be deliberate: in the change that needs it, with
+# the reason in the commit.
+
+budget_bytes = 13000000

--- a/docs/milestone-508.md
+++ b/docs/milestone-508.md
@@ -1,0 +1,64 @@
+# Milestone 508 — What the counter weighs, and a check that says so
+
+Answers [#9](https://github.com/KalybosPro/frus/issues/9).
+
+Milestone 292 found where 286 MB went (symbols, in a debug build), set a release profile,
+and made the fonts a choice. What it could not do was keep the answer true: nothing in CI
+would notice if the smallest application doubled tomorrow.
+
+## Today's number
+
+`frus-hello`, the counter, built for `aarch64-linux-android` with the workspace's release
+profile — the stripped library an APK ships:
+
+| | `.so` | gzip -9 |
+|---|---|---|
+| milestone 292 | 10,012,520 | — |
+| milestone 508 | **10,427,568** | 4,794,223 |
+
+Four per cent in two hundred and sixteen milestones, which is what drift looks like here.
+
+## The check
+
+- **`ci/size-budget.toml`** holds the budget, `budget_bytes = 13000000`, with the argument
+  for it written above the number — a file someone can read and edit, not a constant in a
+  workflow.
+- **`scripts/check-size.sh <library> [budget]`** measures the file, prints its size, its
+  compressed size (what it adds to a zip, for information), the budget and the share of it
+  used — **on every run, a passing one included** — and fails over budget with a message
+  saying what to do about it. It runs by hand as well: that is how it was checked here.
+- **A `size` job** in CI builds the library and runs the script.
+
+### Built without cargo-apk
+
+The library is linked by the NDK's clang directly (API 24, `frus-hello`'s
+`min_sdk_version`) rather than through cargo-apk. The `.so` is what is measured, and a
+release APK needs a signing key the CI does not have and should not be given for this.
+
+### The threshold, argued
+
+About **25% of headroom**. The failures worth catching are jumps:
+
+- the release profile going missing — the debug library was **300 MB**;
+- LTO or stripping turned off;
+- a dependency that arrives with half an ecosystem behind it;
+- a font bundled by default — the four bundled groups are 3.4 MB together.
+
+Each is tens of per cent or more. Drift has been 4% in two hundred milestones, so a quarter
+leaves years of it; a margin of a few per cent would turn the check into a chore that
+gets its budget raised without anyone looking, which is worse than no check.
+
+### Blocking
+
+Unlike the Android APK build next to it, which is advisory while its setup settles, this
+job blocks. It uses only the NDK and the toolchain — no cargo-apk to install — and a check
+that is allowed to be red is a check nobody reads (milestones 294, 298).
+
+## Verification
+
+- The library built and measured in WSL with the same commands the job runs.
+- The script against the committed budget: passes, 80% used, 2,572,432 bytes of headroom.
+- The script against a budget of 9,000,000: fails, with the overage and the instructions,
+  exit status 1.
+- The workflow's first run on GitHub is the pull request's: the NDK path comes from the
+  runner's setup step, which cannot be exercised from here.

--- a/scripts/check-size.sh
+++ b/scripts/check-size.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# Compare a built library's size against the budget committed in the repository
+# (milestone 508, #9). Prints the measurement and the budget on every run, a passing one
+# included -- a check that only speaks when it is angry teaches nobody what normal looks
+# like -- and fails when the library is over budget.
+#
+# Usage:  bash scripts/check-size.sh <library.so> [budget file]
+#
+# The budget file defaults to ci/size-budget.toml and is read for one key, `budget_bytes`.
+set -eu
+
+LIB="${1:?usage: check-size.sh <library.so> [budget file]}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BUDGET_FILE="${2:-$ROOT/ci/size-budget.toml}"
+
+[ -f "$LIB" ] || { echo "error: no library at $LIB" >&2; exit 2; }
+BUDGET="$(sed -n 's/^[[:space:]]*budget_bytes[[:space:]]*=[[:space:]]*\([0-9][0-9]*\).*/\1/p' "$BUDGET_FILE" | head -n 1)"
+[ -n "$BUDGET" ] || { echo "error: no budget_bytes in $BUDGET_FILE" >&2; exit 2; }
+
+SIZE="$(wc -c < "$LIB" | tr -d '[:space:]')"
+# What the library adds to a compressed package, for information only: an APK is a zip.
+COMPRESSED="$(gzip -9 -c "$LIB" | wc -c | tr -d '[:space:]')"
+USED=$(( SIZE * 100 / BUDGET ))
+
+echo "library:    $LIB"
+echo "size:       $SIZE bytes ($COMPRESSED compressed)"
+echo "budget:     $BUDGET bytes ($BUDGET_FILE)"
+echo "used:       $USED% of the budget"
+
+if [ "$SIZE" -gt "$BUDGET" ]; then
+    echo "FAIL: $(( SIZE - BUDGET )) bytes over budget." >&2
+    echo "If the growth is deliberate, raise budget_bytes in $BUDGET_FILE in the same" >&2
+    echo "change and say why; if it is not, something came along that should not have." >&2
+    exit 1
+fi
+echo "OK: $(( BUDGET - SIZE )) bytes of headroom."


### PR DESCRIPTION
Milestone 508, answers #9.

Nothing in CI would notice if the smallest application doubled. A size job now builds frus-hello for aarch64 Android in release -- linked by the NDK's clang directly, since the .so is what is measured and a release APK would need a signing key -- and scripts/check-size.sh compares the stripped library with ci/size-budget.toml, printing the size, the compressed size and the budget on every run, a passing one included.

Today's counter is 10,427,568 bytes, 4% over milestone 292's first measurement. The budget is 13,000,000, about 25% over: there to catch a jump -- the release profile gone, LTO or stripping off, a dependency with an ecosystem behind it, a font bundled by default -- not drift. Blocking, and raised deliberately in the change that needs it.

Checked by hand in WSL: passes at 80% of the budget, fails with exit 1 against a budget of 9,000,000.

Notes in docs/milestone-508.md.

<!--
Thanks for contributing to frus.

Keep the PR focused: one subsystem, one concern. A PR mixing a refactor with a
feature will likely be asked to split.
-->

## What this changes

<!-- One or two sentences. What does the codebase do now that it didn't before? -->

## Why

<!-- The problem this solves. Link the issue: Fixes #123 -->

## How

<!--
The approach, and — more importantly — the alternatives you considered and why
you rejected them. This is the part reviewers care about most.

If this is a milestone (new public API, a subsystem's shape changes, a
trade-off a future reader would question), add `docs/milestone-N.md` and say so here.
-->

## Testing

<!-- What you added, and what you ran. -->

- [ ] `cargo test --workspace` is green
- [ ] `cargo clippy --workspace --all-targets` adds no new warnings
- [ ] `cargo fmt --all -- --check` is clean **on the files I touched**

Platforms actually run on:

- [ ] Windows
- [ ] Linux
- [ ] macOS
- [ ] Android
- [ ] Web (wasm)

New tests:

- [ ] Logic tests (no GPU, no window)
- [ ] Golden tests — *I looked at every generated golden PNG by eye before committing it*
- [ ] Not applicable, because: <!-- explain -->

## Screenshots

<!-- Required for anything visual. Before/after if you changed existing rendering. -->

## Checklist

- [ ] Public items have `///` doc comments
- [ ] Any new styling is **overridable** — themed defaults, no hardcoded colors or dimensions in a widget's paint path
- [ ] No platform-specific code outside `frus-shell`
- [ ] New `unsafe`, if any, has a comment justifying why it is sound (or: none added)
- [ ] Any new gotcha I hit is documented in `CONTRIBUTING.md`

## Notes for the reviewer

<!-- Anything you're unsure about, deliberately left out, or want a second opinion on. -->
